### PR TITLE
Update ch07-01-mod-and-the-filesystem.md

### DIFF
--- a/second-edition/src/ch07-01-mod-and-the-filesystem.md
+++ b/second-edition/src/ch07-01-mod-and-the-filesystem.md
@@ -396,7 +396,7 @@ Here are commands to carry out these steps:
 ```text
 $ mkdir src/network
 $ mv src/network.rs src/network/mod.rs
-$ mv src/server.rs src/network
+$ mv src/server.rs src/network/server.rs
 ```
 
 Now when we try to run `cargo build`, compilation will work (we’ll still have


### PR DESCRIPTION
added missing word in Instruction to copy the 'server.rs' into to folder 'src/network'

## What to expect when you open a pull request here

### 2018 Edition

The 2018 is a "living" edition; it's not scheduled for in-print publication at
this time, and so is able to be updated at any time. We'd love pull requests to
fix issues with this edition, but we're not interested in extremely large
changes without discussing them first. If you'd like to make a big change,
please open an issue first! We'd hate for you to do some hard work that we
ultimately wouldn't accept.

### Second edition

No Starch Press has brought the second edition to print. Pull requests fixing
factual errors will be accepted and documented as errata; pull requests changing
wording or other small corrections should be made against the 2018 edition instead.

### First edition

The first edition is frozen, and no longer accepting changes. Pull requests
made against it will be closed.


Thank you for reading, you may now delete this text!
